### PR TITLE
Fixes issue auto/teleop bug

### DIFF
--- a/src/main/java/org/uacr/services/states/StatesService.java
+++ b/src/main/java/org/uacr/services/states/StatesService.java
@@ -118,11 +118,11 @@ public class StatesService implements ScheduledService {
                 }
             } else if (nextFmsMode == FMS.Mode.DISABLED) {
                 sLogger.info("Current mode {} next mode {}", mCurrentFmsMode, nextFmsMode);
-                if (mCurrentFmsMode != FMS.Mode.AUTONOMOUS) {
+  //              if (mCurrentFmsMode != FMS.Mode.AUTONOMOUS) {
                     fRobotManager.dispose();
                     fStateMachine.dispose();
                     fSharedInputValues.setBoolean("ipb_robot_has_been_zeroed", false);
-                }
+  //              }
             }
         }
 


### PR DESCRIPTION
When an auto is disabled part way through and then teleop is enabled, the auto tries to complete. Thus causing the robot to run into things. This was a desired behavior last year where we wanted autos to complete after the 15 second auto period but this year it is causing problems. Especially when testing.